### PR TITLE
Whomst and code refactor

### DIFF
--- a/include/postlist.php
+++ b/include/postlist.php
@@ -1,31 +1,27 @@
 <?php
 		function makePostBox($filename, $dir) {
-			$f = fopen($dir . "/" . $filename, 'r');
-			$line = trim(fgets($f));
-			$metadata = [];
-			while(substr($line, 0, 4) === "<!--") {
+			$path = $dir . "/" . $filename;
+			$f = fopen($path, 'r');
+			$content = fread($f, filesize($path));
+
+			$metadata = [
+			    "title" => $filename,
+			    "thumb" => "/img/whomst.jpg",
+			    "link" => $path,
+			];
+
+			foreach(explode(PHP_EOL, $content) as $line) {
+				if(substr($line, 0, 4) !== "<!--") continue;
+
 				$info = explode("=", substr($line, 4, -4));
-				$field = $info[0];
-				array_shift($info);
-				$value = implode("=", $info);
-				$line = trim(fgets($f));
-				$metadata[trim($field)] = trim($value);
-			}
+				$val = join("=", array_slice($info, 1));
 
-			if(!$metadata["title"]) {
-				$metadata["title"] = $filename;
-			}
-
-			if(!$metadata["thumb"]) {
-				$metadata["thumb"] = "/img/face-only.png";
+				$metadata[trim($info[0])] = trim($val);
 			}
 
 			$th = $metadata["thumb"];
 			$t = $metadata["title"];
-			$link = $dir . "/" . $filename;
-			if($metadata["link"]) {
-				$link = $metadata["link"];
-			}
+			$link = $metadata["link"];
 
 			echo "
 			<a href='$link'>

--- a/include/postlist.php
+++ b/include/postlist.php
@@ -14,6 +14,8 @@
 				if(substr($line, 0, 4) !== "<!--") continue;
 
 				$info = explode("=", substr($line, 4, -4));
+				if(count($info) < 2) continue;
+				
 				$val = join("=", array_slice($info, 1));
 
 				$metadata[trim($info[0])] = trim($val);


### PR DESCRIPTION
This pr sets `img/whomst.jpg` as the fallback image for postLists.

There was also some code refactoring done as part of this. The refactoring should have no effect on postLists which are correctly configured (i.e. all metadata correctly set in files) but has a couple advantages
- If a field is missing entirely, a fallback is used. Previously, the fallback would only be used if the key was set but a value was not (e.g. `<!-- title -->`). If an important key (e.g. title) was not set at all an error would be produced instead of using the fallback.
- This should make it simple to embed the entire relevant file with since it now has the name `$content`. I assume this was the original intention as metadata is stored in html comments. I haven't done that in this pr as that change would somewhat effect behavior (albeit only by adding comments to the DOM) and figured it should be a pr of its own