### PR TITLE
Update Rust sdk url

### DIFF
--- a/include/nav.php
+++ b/include/nav.php
@@ -13,7 +13,7 @@
     <a href="https://github.com/clydeshaffer/gametankemulator">Emulator Repo</a>
     <br>
     <a href="https://github.com/clydeshaffer/gametank_sdk">C SDK</a>
-    <a href="https://github.com/dwbrite/gametank-rust">Rust SDK</a>
+    <a href="https://github.com/dwbrite/gametank-sdk">Rust SDK</a>
     <br>
     <a href="https://youtube.gametank.zone">Youtube</a>
     <br>


### PR DESCRIPTION
@dwbrite has made a new rust sdk repo, https://github.com/dwbrite/gametank-sdk
The old repo was still linked, which has caused a bit of confusion